### PR TITLE
Fix for Nicotine Addiction not triggering  by Smoking.

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -107,7 +107,7 @@
 ///Minimum requirement for addiction buzz to be met. Addiction code only checks this once every two seconds, so this should generally be low
 #define MIN_ADDICTION_REAGENT_AMOUNT 1
 ///Nicotine requires much less in your system to be happy
-#define MIN_NICOTINE_ADDICTION_REAGENT_AMOUNT 0.1
+#define MIN_NICOTINE_ADDICTION_REAGENT_AMOUNT 0.01
 #define MAX_ADDICTION_POINTS 1000
 
 ///Addiction start/ends


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Single digit change from 0.1 to 0.01 in the required ammount of Nicotine. as smokes burn for 240 ticks and contain up to 20u of it, which is  between 0.01 and 0.0833-

## Why It's Good For The Game

Being able to smoke to fullfill the addiction to smoke would be nice no?

## Changelog
:cl:

fix: Smokers may once again satisfy theyr addiction for smoking, by smoking due to a new supply of less diluted Materials to the supplyers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->

